### PR TITLE
fix: when 'post.careta_at' is null caused the page to crash

### DIFF
--- a/src/component/footer/index.js
+++ b/src/component/footer/index.js
@@ -120,8 +120,8 @@ class Footer extends Component {
               <li>
                 {/* eslint-disable-next-line */}
                 <a
-                  // eslint-disable-next-line
-                  href="javascript: void 0;"
+                  href="#"
+                  onClick={e => e.preventDefault()}
                   target="_blank"
                   rel="noopener noreferrer nofollow"
                 >

--- a/src/pages/post/index.js
+++ b/src/pages/post/index.js
@@ -18,6 +18,8 @@ import actions from "../../redux/actions";
 import "./post.css";
 
 class Post extends Component {
+  isUnmount = false;
+
   state = {
     banners: [
       "35051293-df358be0-fbdf-11e7-9d74-80e8ad97d713",
@@ -226,9 +228,12 @@ class Post extends Component {
                   <span>
                     <Icon type="calendar" style={{ marginRight: "0.5rem" }} />
                     发布于&nbsp;
-                    {formatDistanceToNow(new Date(post.created_at), {
-                      locale: chinese
-                    })}
+                    {formatDistanceToNow(
+                      new Date(post && post.created_at ? post.created_at : 0),
+                      {
+                        locale: chinese
+                      }
+                    )}
                     前
                   </span>
                   <br />

--- a/src/pages/post/index.js
+++ b/src/pages/post/index.js
@@ -226,12 +226,9 @@ class Post extends Component {
                   <span>
                     <Icon type="calendar" style={{ marginRight: "0.5rem" }} />
                     发布于&nbsp;
-                    {formatDistanceToNow(
-                      new Date(post && post.created_at ? post.created_at : 0),
-                      {
-                        locale: chinese
-                      }
-                    )}
+                    {post.created_at
+                      ? formatDistanceToNow(post.created_at)
+                      : ""}
                     前
                   </span>
                   <br />

--- a/src/pages/post/index.js
+++ b/src/pages/post/index.js
@@ -18,8 +18,6 @@ import actions from "../../redux/actions";
 import "./post.css";
 
 class Post extends Component {
-  isUnmount = false;
-
   state = {
     banners: [
       "35051293-df358be0-fbdf-11e7-9d74-80e8ad97d713",

--- a/src/pages/post/index.js
+++ b/src/pages/post/index.js
@@ -226,9 +226,12 @@ class Post extends Component {
                   <span>
                     <Icon type="calendar" style={{ marginRight: "0.5rem" }} />
                     发布于&nbsp;
-                    {post.created_at
-                      ? formatDistanceToNow(post.created_at)
-                      : ""}
+                    {formatDistanceToNow(
+                      new Date(post.created_at ? post.created_at : 0),
+                      {
+                        locale: chinese
+                      }
+                    )}
                     前
                   </span>
                   <br />


### PR DESCRIPTION
- when 'post.careta_at' is null caused page crash, [CC](https://youtu.be/AMFM5nmFyVY) _(•̀ω•́, 

- Fix react 16.9's [warning](https://github.com/axetroy/blog/compare/master...yuxino:master#diff-a53f67632d7ed873853eac2338c6cae3L123-L124) ,  •̀ω•́)_ [CC](https://github.com/facebook/react/issues/16382)